### PR TITLE
🎨 Style: 회원가입, 로그인 페이지 스타일 적용 #1

### DIFF
--- a/frontend/src/pages/LogInPage/LoginPage.tsx
+++ b/frontend/src/pages/LogInPage/LoginPage.tsx
@@ -1,0 +1,11 @@
+import LoginForm from "./components/LoginForm";
+
+const LoginPage = () => {
+  return (
+    <div>
+      <LoginForm />
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/LogInPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LogInPage/components/LoginForm.tsx
@@ -23,7 +23,6 @@ const InputStyle = styled.input`
   font-size: 15px;
   outline-style: none;
   border-radius: 10px;
-  box-sizing: border-box;
   border: 1px solid black;
   padding: 16px 22px;
   margin-bottom: 27px;
@@ -39,7 +38,6 @@ const LoginBtn = styled.button`
   height: 60px;
   border-radius: 10px;
   background-color: #474040;
-  box-sizing: border-box;
   color: #f3f3f3;
   border-style: none;
   font-size: 18px;

--- a/frontend/src/pages/LogInPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LogInPage/components/LoginForm.tsx
@@ -1,0 +1,97 @@
+import MainLayout from "@/layouts/MainLayout";
+import { useState } from "react";
+import styled from "styled-components";
+import logo from "@assets/images/quoteLogo.png";
+
+const Container = styled.form`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 95px;
+`;
+const Header = styled.div`
+  margin-bottom: 96px;
+`;
+const Logo = styled.img`
+  width: 340px;
+`;
+const InputStyle = styled.input`
+  width: 500px;
+  height: 55px;
+  font-size: 15px;
+  outline-style: none;
+  border-radius: 10px;
+  box-sizing: border-box;
+  border: 1px solid black;
+  padding: 16px 22px;
+  margin-bottom: 27px;
+`;
+const ErrorMessage = styled.div`
+  color: #d72121;
+  font-size: 12px;
+  width: 500px;
+  margin: 6px 0 24px 0;
+`;
+const LoginBtn = styled.button`
+  width: 500px;
+  height: 60px;
+  border-radius: 10px;
+  background-color: #474040;
+  box-sizing: border-box;
+  color: #f3f3f3;
+  border-style: none;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 27px;
+  cursor: pointer;
+  padding: 18px 0;
+`;
+const MoveToSignUp = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 47px;
+`;
+const CopyRight = styled.span`
+  font-size: 12px;
+  font-weight: bold;
+  color: #474040;
+`;
+
+const LoginForm = () => {
+  const [errMsg, setErrorMsg] = useState("");
+  return (
+    <MainLayout>
+      <Container>
+        <Header>
+          <Logo src={logo} />
+        </Header>
+        <InputStyle
+          type='text'
+          placeholder='이메일 입력'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <InputStyle
+          type='text'
+          placeholder='비밀번호 입력'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <LoginBtn type='submit'>로그인</LoginBtn>
+
+        <MoveToSignUp>
+          <span style={{ color: "#a7a7a7" }}>
+            아직 회원이 아니신가요?&nbsp;
+          </span>
+          <span style={{ color: "#474040", cursor: "pointer" }}>회원가입</span>
+        </MoveToSignUp>
+
+        <CopyRight>Copyright © TEAM333333 All Rights Reserved.</CopyRight>
+      </Container>
+    </MainLayout>
+  );
+};
+
+export default LoginForm;

--- a/frontend/src/pages/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,0 +1,11 @@
+import SignUpForm from './components/SignUpForm';
+
+const SignUpPage = () => {
+  return (
+    <div>
+      <SignUpForm />
+    </div>
+  );
+};
+
+export default SignUpPage;

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -23,7 +23,6 @@ const InputStyle = styled.input`
   font-size: 15px;
   outline-style: none;
   border-radius: 10px;
-  box-sizing: border-box;
   border: 1px solid black;
   padding: 16px 22px;
   margin-bottom: 27px;
@@ -39,7 +38,6 @@ const SignUpBtn = styled.button`
   height: 60px;
   border-radius: 10px;
   background-color: #474040;
-  box-sizing: border-box;
   color: #f3f3f3;
   border-style: none;
   font-size: 18px;

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -1,0 +1,110 @@
+import MainLayout from "@/layouts/MainLayout";
+import { useState } from "react";
+import styled from "styled-components";
+import logo from "@assets/images/quoteLogo.png";
+
+const Container = styled.form`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 95px;
+`;
+const Header = styled.div`
+  margin-bottom: 96px;
+`;
+const Logo = styled.img`
+  width: 340px;
+`;
+const InputStyle = styled.input`
+  width: 500px;
+  height: 55px;
+  font-size: 15px;
+  outline-style: none;
+  border-radius: 10px;
+  box-sizing: border-box;
+  border: 1px solid black;
+  padding: 16px 22px;
+  margin-bottom: 27px;
+`;
+const ErrorMessage = styled.div`
+  color: #d72121;
+  font-size: 12px;
+  width: 500px;
+  margin: 6px 0 24px 0;
+`;
+const SignUpBtn = styled.button`
+  width: 500px;
+  height: 60px;
+  border-radius: 10px;
+  background-color: #474040;
+  box-sizing: border-box;
+  color: #f3f3f3;
+  border-style: none;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 27px;
+  cursor: pointer;
+  padding: 18px 0;
+`;
+const MoveToLogin = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 47px;
+`;
+const CopyRight = styled.span`
+  font-size: 12px;
+  font-weight: bold;
+  color: #474040;
+`;
+
+const SignUpForm = () => {
+  const [errMsg, setErrorMsg] = useState("");
+
+  return (
+    <MainLayout>
+      <Container>
+        <Header>
+          <Logo src={logo} />
+        </Header>
+        <InputStyle
+          type='text'
+          placeholder='닉네임 입력'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <InputStyle
+          type='text'
+          placeholder='이메일 입력'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <InputStyle
+          type='text'
+          placeholder='비밀번호 입력(영문, 숫자, 특수문자 포함 8~15자)'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <InputStyle
+          type='text'
+          placeholder='비밀번호 확인'
+        />
+        <ErrorMessage>{errMsg}</ErrorMessage>
+
+        <SignUpBtn type='submit'>회원가입</SignUpBtn>
+
+        <MoveToLogin>
+          <span style={{ color: "#a7a7a7" }}>
+            이미 계정이 있으신가요?&nbsp;
+          </span>
+          <span style={{ color: "#474040", cursor: "pointer" }}>로그인</span>
+        </MoveToLogin>
+
+        <CopyRight>Copyright © TEAM333333 All Rights Reserved.</CopyRight>
+      </Container>
+    </MainLayout>
+  );
+};
+
+export default SignUpForm;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 회원가입, 로그인 페이지 스타일 적용

## 📝 요구 사항과 구현 내용
- 회원가입 페이지와 로그인 페이지 로고, 입력 폼, 버튼, 카피라이트 등 전체적인 스타일 적용
- 에러메세지는 위치만 잡아둔 상태

## 💬 PR 포인트 & 궁금한 점
- 헤더 부분은 로그아웃 기능까지 완성한 후에 안 보이게 처리할 예정
- 회원가입 페이지에서 로그인 페이지로 이동하는 것, 로그인 페이지에서 회원가입 페이지로 이동하는 것도 추후 적용 예정

## 🔗 연관된 이슈
- close #1
