### PR TITLE
✨ Feat: 회원가입 완료 후 알림 띄우고 로그인 페이지로 이동 #10

### DIFF
--- a/frontend/src/pages/LogInPage/apis/login.ts
+++ b/frontend/src/pages/LogInPage/apis/login.ts
@@ -1,0 +1,28 @@
+import { authAxiosClient } from "@/pages/SignUpPage/apis/signUp"
+import axios from "axios";
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+export const loginRequest = async (user: LoginData) => {
+  try {
+    const res = await authAxiosClient.post('/users/signin', user);
+
+    if (res.status === 200) {
+      console.log("Login Success");
+      return res.data; 
+    } 
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      const status = err.response?.status;
+
+      if (status === 500) {
+        console.error("Server error");
+      }
+
+      return null;
+    }
+  }
+}

--- a/frontend/src/pages/LogInPage/apis/login.ts
+++ b/frontend/src/pages/LogInPage/apis/login.ts
@@ -22,7 +22,10 @@ export const loginRequest = async (user: LoginData) => {
         console.error("Server error");
       }
 
-      return null;
+      throw err;
+    } else {
+      console.error("Unexpected Error");
+      throw err;
     }
   }
 }

--- a/frontend/src/pages/LogInPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LogInPage/components/LoginForm.tsx
@@ -22,7 +22,7 @@ const InputDiv = styled.div`
 `;
 const InputStyle = styled.input`
   width: 400px;
-  height: 43px;
+  height: 46px;
   font-size: 12px;
   outline-style: none;
   border-radius: 10px;
@@ -46,7 +46,7 @@ const ErrorMessage = styled.div`
 `;
 const LoginBtn = styled.button`
   width: 400px;
-  height: 45px;
+  height: 48px;
   border-radius: 10px;
   background-color: #474040;
   color: #f3f3f3;

--- a/frontend/src/pages/LogInPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LogInPage/components/LoginForm.tsx
@@ -24,7 +24,7 @@ const InputDiv = styled.div`
 const InputStyle = styled.input`
   width: 400px;
   height: 46px;
-  font-size: 12px;
+  font-size: 14px;
   outline-style: none;
   border-radius: 10px;
   border: 0.9px solid black;

--- a/frontend/src/pages/LogInPage/components/LoginForm.tsx
+++ b/frontend/src/pages/LogInPage/components/LoginForm.tsx
@@ -1,7 +1,8 @@
 import MainLayout from "@/layouts/MainLayout";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import styled from "styled-components";
 import logo from "@assets/images/quoteLogo.png";
+import { Link } from "react-router-dom";
 
 const Container = styled.form`
   width: 100%;
@@ -9,73 +10,95 @@ const Container = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 95px;
 `;
 const Header = styled.div`
-  margin-bottom: 96px;
+  margin: 60px 0;
 `;
 const Logo = styled.img`
-  width: 340px;
+  width: 250px;
+`;
+const InputDiv = styled.div`
+  margin-bottom: 20px;
 `;
 const InputStyle = styled.input`
-  width: 500px;
-  height: 55px;
-  font-size: 15px;
+  width: 400px;
+  height: 43px;
+  font-size: 12px;
   outline-style: none;
   border-radius: 10px;
-  border: 1px solid black;
-  padding: 16px 22px;
-  margin-bottom: 27px;
+  border: 0.9px solid black;
+  padding: 16px;
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px #fff inset;
+    -webkit-text-fill-color: #000;
+  }
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    transition: background-color 5000s ease-in-out 0s;
+  }
 `;
 const ErrorMessage = styled.div`
   color: #d72121;
   font-size: 12px;
-  width: 500px;
-  margin: 6px 0 24px 0;
+  margin: 6px 0 0 10px;
 `;
 const LoginBtn = styled.button`
-  width: 500px;
-  height: 60px;
+  width: 400px;
+  height: 45px;
   border-radius: 10px;
   background-color: #474040;
   color: #f3f3f3;
   border-style: none;
-  font-size: 18px;
-  font-weight: bold;
-  margin-bottom: 27px;
-  cursor: pointer;
-  padding: 18px 0;
-`;
-const MoveToSignUp = styled.div`
   font-size: 14px;
   font-weight: bold;
-  margin-bottom: 47px;
+  margin: 20px 0 27px 0;
+  cursor: pointer;
+  padding: 10px 0;
+`;
+const MoveToSignUp = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 65px;
 `;
 const CopyRight = styled.span`
-  font-size: 12px;
+  font-size: 10px;
   font-weight: bold;
   color: #474040;
 `;
 
 const LoginForm = () => {
   const [errMsg, setErrorMsg] = useState("");
+
+  const onSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
   return (
     <MainLayout>
-      <Container>
+      <Container onSubmit={onSubmitHandler}>
         <Header>
           <Logo src={logo} />
         </Header>
-        <InputStyle
-          type='text'
-          placeholder='이메일 입력'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
 
-        <InputStyle
-          type='text'
-          placeholder='비밀번호 입력'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='이메일 입력'
+            name='email'
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
+
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='비밀번호 입력'
+            name='password'
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
 
         <LoginBtn type='submit'>로그인</LoginBtn>
 
@@ -83,7 +106,19 @@ const LoginForm = () => {
           <span style={{ color: "#a7a7a7" }}>
             아직 회원이 아니신가요?&nbsp;
           </span>
-          <span style={{ color: "#474040", cursor: "pointer" }}>회원가입</span>
+          <Link
+            to='/signup'
+            style={{ textDecoration: "none" }}
+          >
+            <span
+              style={{
+                color: "#474040",
+                cursor: "pointer",
+              }}
+            >
+              회원가입
+            </span>
+          </Link>
         </MoveToSignUp>
 
         <CopyRight>Copyright © TEAM333333 All Rights Reserved.</CopyRight>

--- a/frontend/src/pages/LogInPage/hooks/useLogin.ts
+++ b/frontend/src/pages/LogInPage/hooks/useLogin.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query"
+import { loginRequest } from "../apis/login"
+import { useNavigate } from "react-router-dom"
+
+export const useLogin = () => {
+  const navigate = useNavigate();
+  const loginMutation = useMutation({
+    mutationFn: loginRequest,
+
+    onSuccess: () => {
+      console.log("Login Success");
+      navigate('/');
+    },
+    onError: (err) => {
+      console.error("Error: ", err);
+    }
+  })
+  return loginMutation;
+}

--- a/frontend/src/pages/SignUpPage/apis/signUp.ts
+++ b/frontend/src/pages/SignUpPage/apis/signUp.ts
@@ -20,7 +20,7 @@ export const authAxiosClient: AxiosInstance = axios.create({
 //회원가입 요청
 export const signUpRequest = async (newUser: SignUpData) => {
   try {
-    const res = await authAxiosClient.post('/signup', newUser);
+    const res = await authAxiosClient.post('/users/signup', newUser);
 
     if (res.status === 200) {
       console.log("SignUp Success");

--- a/frontend/src/pages/SignUpPage/apis/signUp.ts
+++ b/frontend/src/pages/SignUpPage/apis/signUp.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosInstance } from "axios";
+
+interface SignUpData {
+  nickname: string;
+  email: string;
+  password: string;
+}
+
+const siteUrl = "http://43.200.164.241:8000/"
+
+//회원가입과 로그인에 사용할 axiosClient
+export const authAxiosClient: AxiosInstance = axios.create({
+  baseURL: siteUrl,
+  timeout: 2000,
+  headers: {
+    accept: 'application/json'
+  }
+});
+
+//회원가입 요청
+export const signUpRequest = async (newUser: SignUpData) => {
+  try {
+    const res = await authAxiosClient.post('/signup', newUser);
+
+    if (res.status === 200) {
+      console.log("SignUp Success");
+      return res.data;
+    } 
+  } catch (err) {
+    if (axios.isAxiosError(err)) {
+      const status = err.response?.status;
+
+      if (status === 500) {
+        console.error("Server error");
+      }
+
+      return null;
+    }
+  }
+}

--- a/frontend/src/pages/SignUpPage/apis/signUp.ts
+++ b/frontend/src/pages/SignUpPage/apis/signUp.ts
@@ -30,11 +30,17 @@ export const signUpRequest = async (newUser: SignUpData) => {
     if (axios.isAxiosError(err)) {
       const status = err.response?.status;
 
+      if (status === 400) {
+        console.error("Duplicate error");
+      } 
       if (status === 500) {
         console.error("Server error");
       }
 
-      return null;
+      throw err;
+    } else {
+      console.error("Unexpected Error");
+      throw err;
     }
   }
 }

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -5,7 +5,7 @@ import logo from "@assets/images/quoteLogo.png";
 import { Link } from "react-router-dom";
 import { useSignUp } from "../hooks/useSignUp";
 
-const Container = styled.form`
+const Container = styled.div`
   width: 100%;
   display: flex;
   height: 100vh;
@@ -39,10 +39,14 @@ const InputStyle = styled.input`
   &:-webkit-autofill:active {
     transition: background-color 5000s ease-in-out 0s;
   }
+  //password타입일 때 글꼴때문에 입력되는 것이 안 보여서 글꼴 수정
+  &[type="password"] {
+    font-family: Arial, Helvetica, sans-serif;
+  }
 `;
 const ErrorMessage = styled.div`
   color: #d72121;
-  font-size: 12px;
+  font-size: 10px;
   margin: 6px 0 0 10px;
 `;
 const SignUpBtn = styled.button`
@@ -76,6 +80,13 @@ interface SignUpData {
   checkPwd: string;
 }
 
+interface ErrorMessage {
+  nicknameErr?: string;
+  emailErr?: string;
+  passwordErr?: string;
+  checkPwdErr?: string;
+}
+
 const SignUpForm = () => {
   const [info, setInfo] = useState<SignUpData>({
     nickname: "",
@@ -83,112 +94,158 @@ const SignUpForm = () => {
     password: "",
     checkPwd: "",
   });
-  const [checkPwd, setCheckPwd] = useState("");
-  const [errMsg, setErrorMsg] = useState("");
-  const { mutate: signUp } = useSignUp();
+  const [errMsg, setErrorMsg] = useState<ErrorMessage>({});
+  const { mutate: signUp } = useSignUp({
+    nicknameErr: errMsg.nicknameErr,
+    emailErr: errMsg.emailErr,
+  });
 
+  //input값 반영
   const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const { name, value } = e.target;
     setInfo({ ...info, [name]: value });
   };
 
-  //입력값이 유효한지 확인
-  const isValid = (data: string) => {
-    if (data === info.nickname) {
-      const nicknameRegex = /^[^\s]{1,8}$/;
-      return nicknameRegex.test(data);
+  //닉네임 입력 형식이 유효한지 확인
+  const isValidNickname = (nickname: string) => {
+    const nicknameRegex = /^[^\s]{1,8}$/;
+    return nicknameRegex.test(nickname);
+  };
+
+  //닉네임 입력 형식이 유효한지 확인
+  const isValidEmail = (email: string) => {
+    const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+    return emailRegex.test(email);
+  };
+
+  //비밀번호 형식이 유효한지 확인
+  const isValidPwd = (pwd: string) => {
+    const pwdRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,15}$/;
+    return pwdRegex.test(pwd);
+  };
+
+  //비밀번호 일치하는지 확인
+  const doubleCheckPwd = (checkPwd: string) => {
+    if (info.password === checkPwd) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  //유효하지 않으면 에러 반환
+  const isValid = () => {
+    const errors: ErrorMessage = {
+      nicknameErr: "",
+      emailErr: "",
+      passwordErr: "",
+      checkPwdErr: "",
+    };
+
+    if (!isValidNickname(info.nickname)) {
+      errors.nicknameErr = "닉네임은 공백 없이 8자 이내로 입력해주세요.";
+    }
+    if (!isValidEmail(info.email)) {
+      errors.emailErr = "아이디는 이메일 형식을 만족해야 합니다.";
+    }
+    if (!isValidPwd(info.password)) {
+      errors.passwordErr =
+        "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함하여 8~15자 이내로 입력해주세요.";
+    }
+    if (!doubleCheckPwd(info.checkPwd)) {
+      errors.checkPwdErr = "비밀번호가 일치하지 않습니다.";
     }
 
-    if (data === info.email) {
-      const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
-      return emailRegex.test(data);
-    }
-
-    if (data === info.password) {
-      const pwdRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,15}$/;
-      return pwdRegex.test(data);
-    }
+    return errors;
   };
 
   //새로운 유저 정보 전송
   const onSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    const errors = isValid();
     const newUser = {
       nickname: info.nickname,
       email: info.email,
       password: info.password,
     };
 
-    const validation =
-      isValid(info.email) &&
-      isValid(info.nickname) &&
-      isValid(info.password) &&
-      info.password === info.checkPwd;
-
-    const result = signUp(newUser);
-
-    if (validation) {
-      return result;
+    if (
+      isValidEmail(info.email) &&
+      isValidNickname(info.nickname) &&
+      isValidPwd(info.password) &&
+      doubleCheckPwd(info.checkPwd)
+    ) {
+      signUp(newUser);
+    } else {
+      setErrorMsg(errors);
     }
   };
 
   return (
     <MainLayout>
-      <Container onSubmit={onSubmitHandler}>
+      <Container>
         <Header>
           <Logo src={logo} />
         </Header>
 
-        <InputDiv>
-          <InputStyle
-            type='text'
-            placeholder='닉네임 입력'
-            name='nickname'
-            value={info.nickname}
-            onChange={handleChange}
-            required
-          />
-          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
-        </InputDiv>
+        <form onSubmit={onSubmitHandler}>
+          <InputDiv>
+            <InputStyle
+              type='text'
+              placeholder='닉네임 입력'
+              name='nickname'
+              value={info.nickname}
+              onChange={handleChange}
+              required
+            />
+            {errMsg.nicknameErr && (
+              <ErrorMessage>{errMsg.nicknameErr}</ErrorMessage>
+            )}
+          </InputDiv>
 
-        <InputDiv>
-          <InputStyle
-            type='text'
-            placeholder='이메일 입력'
-            name='email'
-            value={info.email}
-            onChange={handleChange}
-            required
-          />
-          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
-        </InputDiv>
+          <InputDiv>
+            <InputStyle
+              type='email'
+              placeholder='이메일 입력'
+              name='email'
+              value={info.email}
+              onChange={handleChange}
+              required
+            />
+            {errMsg.emailErr && <ErrorMessage>{errMsg.emailErr}</ErrorMessage>}
+          </InputDiv>
 
-        <InputDiv>
-          <InputStyle
-            type='text'
-            placeholder='비밀번호 입력(영문 대소문자, 숫자, 특수문자 포함 8~15자)'
-            name='password'
-            value={info.password}
-            onChange={handleChange}
-            required
-          />
-          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
-        </InputDiv>
+          <InputDiv>
+            <InputStyle
+              type='password'
+              placeholder='비밀번호 입력(영문 대소문자, 숫자, 특수문자 포함 8~15자)'
+              name='password'
+              value={info.password}
+              onChange={handleChange}
+              required
+            />
+            {errMsg.passwordErr && (
+              <ErrorMessage>{errMsg.passwordErr}</ErrorMessage>
+            )}
+          </InputDiv>
 
-        <InputDiv>
-          <InputStyle
-            type='text'
-            placeholder='비밀번호 확인'
-            name='checkPwd'
-            value={checkPwd}
-            onChange={handleChange}
-            required
-          />
-          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
-        </InputDiv>
+          <InputDiv>
+            <InputStyle
+              type='password'
+              placeholder='비밀번호 확인'
+              name='checkPwd'
+              value={info.checkPwd}
+              onChange={handleChange}
+              required
+            />
+            {errMsg.checkPwdErr && (
+              <ErrorMessage>{errMsg.checkPwdErr}</ErrorMessage>
+            )}
+          </InputDiv>
 
-        <SignUpBtn type='submit'>회원가입</SignUpBtn>
+          <SignUpBtn type='submit'>회원가입</SignUpBtn>
+        </form>
 
         <MoveToLogin>
           <span style={{ color: "#a7a7a7" }}>

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -1,8 +1,8 @@
 import MainLayout from "@/layouts/MainLayout";
 import { ChangeEvent, FormEvent, useState } from "react";
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import logo from "@assets/images/quoteLogo.png";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useSignUp } from "../hooks/useSignUp";
 
 const Container = styled.div`
@@ -24,7 +24,7 @@ const InputDiv = styled.div`
 const InputStyle = styled.input`
   width: 400px;
   height: 46px;
-  font-size: 12px;
+  font-size: 14px;
   outline-style: none;
   border-radius: 10px;
   border: 0.9px solid black;
@@ -46,7 +46,7 @@ const InputStyle = styled.input`
 `;
 const ErrorMessage = styled.div`
   color: #d72121;
-  font-size: 10px;
+  font-size: 12px;
   margin: 6px 0 0 10px;
 `;
 const SignUpBtn = styled.button`
@@ -72,6 +72,10 @@ const CopyRight = styled.span`
   font-weight: bold;
   color: #474040;
 `;
+const fadeOut = keyframes`
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+`;
 const AlertStyle = styled.div`
   width: 200px;
   font-size: 14px;
@@ -86,6 +90,8 @@ const AlertStyle = styled.div`
   transform: translate(-50%, 5%);
   border-radius: 10px;
   box-shadow: 0 0 5px gray;
+  opacity: 1;
+  animation: ${fadeOut} 2s ease-in-out 1s forwards;
 `;
 
 interface SignUpData {
@@ -104,16 +110,26 @@ export interface ErrorMessage {
 }
 
 const SignUpForm = () => {
+  const navigate = useNavigate();
   const [info, setInfo] = useState<SignUpData>({
     nickname: "",
     email: "",
     password: "",
     checkPwd: "",
   });
-  const [alert, setAlert] = useState("alert");
+  const [alert, setAlert] = useState("");
   const [errMsg, setErrorMsg] = useState<ErrorMessage>({});
+
+  const showAlert = () => {
+    setAlert("회원가입이 완료되었습니다.");
+    setTimeout(() => {
+      setAlert("");
+      navigate("/login");
+    }, 2000);
+  };
+
   const { mutate: signUp } = useSignUp({
-    setAlert: setAlert,
+    showAlert: showAlert,
     setError: setErrorMsg,
   });
 
@@ -167,7 +183,7 @@ const SignUpForm = () => {
     }
     if (!isValidPwd(info.password)) {
       errors.passwordErr =
-        "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함하여 8~15자 이내로 입력해주세요.";
+        "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~15자 이내로 입력해주세요.";
     }
     if (!doubleCheckPwd(info.checkPwd)) {
       errors.checkPwdErr = "비밀번호가 일치하지 않습니다.";
@@ -237,7 +253,7 @@ const SignUpForm = () => {
           <InputDiv>
             <InputStyle
               type='password'
-              placeholder='비밀번호 입력(영문 대소문자, 숫자, 특수문자 포함 8~15자)'
+              placeholder='비밀번호 입력(영문, 숫자, 특수문자 포함 8~15자)'
               name='password'
               value={info.password}
               onChange={handleChange}

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -72,6 +72,21 @@ const CopyRight = styled.span`
   font-weight: bold;
   color: #474040;
 `;
+const AlertStyle = styled.div`
+  width: 200px;
+  font-size: 14px;
+  height: 40px;
+  text-align: center;
+  line-height: 40px;
+  background-color: #ffffff;
+  color: 393939;
+  position: fixed;
+  top: 5%;
+  left: 50%;
+  transform: translate(-50%, 5%);
+  border-radius: 10px;
+  box-shadow: 0 0 5px gray;
+`;
 
 interface SignUpData {
   nickname: string;
@@ -80,11 +95,12 @@ interface SignUpData {
   checkPwd: string;
 }
 
-interface ErrorMessage {
+export interface ErrorMessage {
   nicknameErr?: string;
   emailErr?: string;
   passwordErr?: string;
   checkPwdErr?: string;
+  message?: string;
 }
 
 const SignUpForm = () => {
@@ -94,8 +110,12 @@ const SignUpForm = () => {
     password: "",
     checkPwd: "",
   });
+  const [alert, setAlert] = useState("alert");
   const [errMsg, setErrorMsg] = useState<ErrorMessage>({});
-  const { mutate: signUp } = useSignUp();
+  const { mutate: signUp } = useSignUp({
+    setAlert: setAlert,
+    setError: setErrorMsg,
+  });
 
   //input값 반영
   const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
@@ -109,7 +129,7 @@ const SignUpForm = () => {
     return nicknameRegex.test(nickname);
   };
 
-  //닉네임 입력 형식이 유효한지 확인
+  //이메일 입력 형식이 유효한지 확인
   const isValidEmail = (email: string) => {
     const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
     return emailRegex.test(email);
@@ -259,6 +279,7 @@ const SignUpForm = () => {
 
         <CopyRight>Copyright © TEAM333333 All Rights Reserved.</CopyRight>
       </Container>
+      {alert && <AlertStyle>{alert}</AlertStyle>}
     </MainLayout>
   );
 };

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -23,7 +23,7 @@ const InputDiv = styled.div`
 `;
 const InputStyle = styled.input`
   width: 400px;
-  height: 43px;
+  height: 46px;
   font-size: 12px;
   outline-style: none;
   border-radius: 10px;
@@ -51,7 +51,7 @@ const ErrorMessage = styled.div`
 `;
 const SignUpBtn = styled.button`
   width: 400px;
-  height: 45px;
+  height: 48px;
   border-radius: 10px;
   background-color: #474040;
   color: #f3f3f3;
@@ -95,10 +95,7 @@ const SignUpForm = () => {
     checkPwd: "",
   });
   const [errMsg, setErrorMsg] = useState<ErrorMessage>({});
-  const { mutate: signUp } = useSignUp({
-    nicknameErr: errMsg.nicknameErr,
-    emailErr: errMsg.emailErr,
-  });
+  const { mutate: signUp } = useSignUp();
 
   //input값 반영
   const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
@@ -162,6 +159,7 @@ const SignUpForm = () => {
   //새로운 유저 정보 전송
   const onSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setErrorMsg({}); //버튼 누를 때 이전 에러 메세지 없애기
 
     const errors = isValid();
     const newUser = {
@@ -206,7 +204,7 @@ const SignUpForm = () => {
 
           <InputDiv>
             <InputStyle
-              type='email'
+              type='text'
               placeholder='이메일 입력'
               name='email'
               value={info.email}

--- a/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
+++ b/frontend/src/pages/SignUpPage/components/SignUpForm.tsx
@@ -1,94 +1,192 @@
 import MainLayout from "@/layouts/MainLayout";
-import { useState } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
 import styled from "styled-components";
 import logo from "@assets/images/quoteLogo.png";
+import { Link } from "react-router-dom";
+import { useSignUp } from "../hooks/useSignUp";
 
 const Container = styled.form`
   width: 100%;
-  height: 100vh;
   display: flex;
+  height: 100vh;
   flex-direction: column;
   align-items: center;
-  margin-top: 95px;
 `;
 const Header = styled.div`
-  margin-bottom: 96px;
+  margin: 60px 0;
 `;
 const Logo = styled.img`
-  width: 340px;
+  width: 250px;
+`;
+const InputDiv = styled.div`
+  margin-bottom: 20px;
 `;
 const InputStyle = styled.input`
-  width: 500px;
-  height: 55px;
-  font-size: 15px;
+  width: 400px;
+  height: 43px;
+  font-size: 12px;
   outline-style: none;
   border-radius: 10px;
-  border: 1px solid black;
-  padding: 16px 22px;
-  margin-bottom: 27px;
+  border: 0.9px solid black;
+  padding: 16px;
+  &:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px #fff inset;
+    -webkit-text-fill-color: #000;
+  }
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    transition: background-color 5000s ease-in-out 0s;
+  }
 `;
 const ErrorMessage = styled.div`
   color: #d72121;
   font-size: 12px;
-  width: 500px;
-  margin: 6px 0 24px 0;
+  margin: 6px 0 0 10px;
 `;
 const SignUpBtn = styled.button`
-  width: 500px;
-  height: 60px;
+  width: 400px;
+  height: 45px;
   border-radius: 10px;
   background-color: #474040;
   color: #f3f3f3;
   border-style: none;
-  font-size: 18px;
-  font-weight: bold;
-  margin-bottom: 27px;
-  cursor: pointer;
-  padding: 18px 0;
-`;
-const MoveToLogin = styled.div`
   font-size: 14px;
   font-weight: bold;
-  margin-bottom: 47px;
+  margin: 20px 0 27px 0;
+  cursor: pointer;
+  padding: 10px 0;
+`;
+const MoveToLogin = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 65px;
 `;
 const CopyRight = styled.span`
-  font-size: 12px;
+  font-size: 10px;
   font-weight: bold;
   color: #474040;
 `;
 
+interface SignUpData {
+  nickname: string;
+  email: string;
+  password: string;
+  checkPwd: string;
+}
+
 const SignUpForm = () => {
+  const [info, setInfo] = useState<SignUpData>({
+    nickname: "",
+    email: "",
+    password: "",
+    checkPwd: "",
+  });
+  const [checkPwd, setCheckPwd] = useState("");
   const [errMsg, setErrorMsg] = useState("");
+  const { mutate: signUp } = useSignUp();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = e.target;
+    setInfo({ ...info, [name]: value });
+  };
+
+  //입력값이 유효한지 확인
+  const isValid = (data: string) => {
+    if (data === info.nickname) {
+      const nicknameRegex = /^[^\s]{1,8}$/;
+      return nicknameRegex.test(data);
+    }
+
+    if (data === info.email) {
+      const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+      return emailRegex.test(data);
+    }
+
+    if (data === info.password) {
+      const pwdRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,15}$/;
+      return pwdRegex.test(data);
+    }
+  };
+
+  //새로운 유저 정보 전송
+  const onSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const newUser = {
+      nickname: info.nickname,
+      email: info.email,
+      password: info.password,
+    };
+
+    const validation =
+      isValid(info.email) &&
+      isValid(info.nickname) &&
+      isValid(info.password) &&
+      info.password === info.checkPwd;
+
+    const result = signUp(newUser);
+
+    if (validation) {
+      return result;
+    }
+  };
 
   return (
     <MainLayout>
-      <Container>
+      <Container onSubmit={onSubmitHandler}>
         <Header>
           <Logo src={logo} />
         </Header>
-        <InputStyle
-          type='text'
-          placeholder='닉네임 입력'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
 
-        <InputStyle
-          type='text'
-          placeholder='이메일 입력'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='닉네임 입력'
+            name='nickname'
+            value={info.nickname}
+            onChange={handleChange}
+            required
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
 
-        <InputStyle
-          type='text'
-          placeholder='비밀번호 입력(영문, 숫자, 특수문자 포함 8~15자)'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='이메일 입력'
+            name='email'
+            value={info.email}
+            onChange={handleChange}
+            required
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
 
-        <InputStyle
-          type='text'
-          placeholder='비밀번호 확인'
-        />
-        <ErrorMessage>{errMsg}</ErrorMessage>
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='비밀번호 입력(영문 대소문자, 숫자, 특수문자 포함 8~15자)'
+            name='password'
+            value={info.password}
+            onChange={handleChange}
+            required
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
+
+        <InputDiv>
+          <InputStyle
+            type='text'
+            placeholder='비밀번호 확인'
+            name='checkPwd'
+            value={checkPwd}
+            onChange={handleChange}
+            required
+          />
+          {errMsg && <ErrorMessage>{errMsg}</ErrorMessage>}
+        </InputDiv>
 
         <SignUpBtn type='submit'>회원가입</SignUpBtn>
 
@@ -96,7 +194,12 @@ const SignUpForm = () => {
           <span style={{ color: "#a7a7a7" }}>
             이미 계정이 있으신가요?&nbsp;
           </span>
-          <span style={{ color: "#474040", cursor: "pointer" }}>로그인</span>
+          <Link
+            to='/login'
+            style={{ textDecoration: "none" }}
+          >
+            <span style={{ color: "#474040", cursor: "pointer" }}>로그인</span>
+          </Link>
         </MoveToLogin>
 
         <CopyRight>Copyright © TEAM333333 All Rights Reserved.</CopyRight>

--- a/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
+++ b/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
@@ -2,7 +2,12 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom"
 import { signUpRequest } from "../apis/signUp";
 
-export const useSignUp = () => {
+interface duplicateCheck {
+  nicknameErr?: string;
+  emailErr?: string;
+}
+
+export const useSignUp = (setErrorMsg: duplicateCheck) => {
   const signUpMutation = useMutation({
     mutationFn: signUpRequest,
 

--- a/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
+++ b/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
@@ -5,17 +5,17 @@ import axios from "axios";
 import { ErrorMessage } from "../components/SignUpForm";
 
 interface setFunc {
-  setAlert: Dispatch<React.SetStateAction<string>>;
+  showAlert: () => void;
   setError: Dispatch<React.SetStateAction<ErrorMessage>>;
 }
 
-export const useSignUp = ({setAlert, setError}: setFunc) => {
+export const useSignUp = ({showAlert, setError}: setFunc) => {
   const signUpMutation = useMutation({
     mutationFn: signUpRequest,
 
     onSuccess: () => {
       console.log("SignUp Success");
-      setAlert('회원가입이 완료되었습니다.');
+      showAlert();
     },
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response?.status === 400) {

--- a/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
+++ b/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom"
+import { signUpRequest } from "../apis/signUp";
+
+export const useSignUp = () => {
+  const signUpMutation = useMutation({
+    mutationFn: signUpRequest,
+
+    onSuccess: (result) => {
+      console.log("SignUp Success: ", result);
+    },
+    onError: (error) => {
+      console.error("Error: ", error);
+    }
+  })
+  return signUpMutation;
+}

--- a/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
+++ b/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
@@ -1,13 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom"
 import { signUpRequest } from "../apis/signUp";
 
-interface duplicateCheck {
-  nicknameErr?: string;
-  emailErr?: string;
-}
-
-export const useSignUp = (setErrorMsg: duplicateCheck) => {
+export const useSignUp = () => {
   const signUpMutation = useMutation({
     mutationFn: signUpRequest,
 

--- a/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
+++ b/frontend/src/pages/SignUpPage/hooks/useSignUp.ts
@@ -1,14 +1,45 @@
 import { useMutation } from "@tanstack/react-query";
 import { signUpRequest } from "../apis/signUp";
+import React, { Dispatch } from "react";
+import axios from "axios";
+import { ErrorMessage } from "../components/SignUpForm";
 
-export const useSignUp = () => {
+interface setFunc {
+  setAlert: Dispatch<React.SetStateAction<string>>;
+  setError: Dispatch<React.SetStateAction<ErrorMessage>>;
+}
+
+export const useSignUp = ({setAlert, setError}: setFunc) => {
   const signUpMutation = useMutation({
     mutationFn: signUpRequest,
 
-    onSuccess: (result) => {
-      console.log("SignUp Success: ", result);
+    onSuccess: () => {
+      console.log("SignUp Success");
+      setAlert('회원가입이 완료되었습니다.');
     },
     onError: (error) => {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        const { nickname, email, message } = error.response?.data;
+        const errors: ErrorMessage = {
+          nicknameErr: "",
+          emailErr: "",
+          message: ""
+        }
+
+        if (nickname) {
+          errors.nicknameErr = "이미 존재하는 닉네임입니다.";
+        } 
+        if (email) {
+          errors.emailErr = "이미 가입된 이메일입니다.";
+        }
+        if (message === "nickname already taken") {
+          errors.nicknameErr = "이미 존재하는 닉네임입니다."
+        } else if (message === "email already in use") {
+          errors.emailErr = "이미 가입된 이메일입니다.";
+        }
+
+        return setError(errors);
+      }
       console.error("Error: ", error);
     }
   })


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 회원가입 페이지 구현 완료

## 📝 요구 사항과 구현 내용
- 닉네임, 이메일, 비밀번호, 비밀번호 확인란 정규식에 따라 유효성 검사
- 유효성 검사 후 유효하지 않으면 에러 띄우기
- 유효성 검사 통과하면 새로운 회원 정보 전송
- 이미 있는 닉네임, 이메일이면 회원가입되지 않고 경고 출력
- 회원가입 완료 후 알림 띄우고 로그인 페이지로 이동

## 💬 PR 포인트 & 궁금한 점
- 이상한 점이나 고쳐야 되는 부분 있으면 알려주세요!

## 🔗 연관된 이슈
- close #10