### PR TITLE
🎨 Style : 다른 유저 페이지 스타일 적용

### DIFF
--- a/frontend/src/pages/UserPages/UserPage.tsx
+++ b/frontend/src/pages/UserPages/UserPage.tsx
@@ -1,0 +1,187 @@
+import styled from "styled-components";
+import profile from "@assets/images/profile.png";
+import MainLayout from "@/layouts/MainLayout";
+import WriteButton from "@/components/WriteButton/WriteButton";
+import PostCard from "./components/PostCard";
+import { Post } from "@/types/Types";
+
+// Styled Components
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  caret-color: transparent;
+  overflow: hidden;
+`;
+
+const ProfileSection = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 70px;
+  width: 100%;
+  max-width: 600px;
+`;
+
+const ProfileImage = styled.img`
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin-top: 50px;
+  border-radius: 50%;
+`;
+
+const UserName = styled.h2`
+  margin-top: 20px;
+  font-size: 20px;
+  color: #303030;
+  text-align: center;
+`;
+
+const UserEmail = styled.p`
+  margin-top: 5px;
+  font-size: 10px;
+  color: #a7a7a7;
+  text-align: center;
+`;
+
+const ContentSection = styled.div`
+  width: 860px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
+`;
+
+const TabLabel = styled.h3`
+  width: 100%;
+  height: 100%;
+  background: none;
+  border: none;
+  font-size: 18px;
+  text-align: center;
+  color: #303030;
+  border-bottom: 2px solid black;
+`;
+
+const MessageContainer = styled.div`
+  margin-top: 50px;
+  font-size: 18px;
+  color: #a7a7a7;
+  text-align: center;
+`;
+
+const PostContainer = styled.div`
+  width: 840px;
+  height: 100%;
+  margin: 30px auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+`;
+
+const UserPage = () => {
+  const hasPosts = sampleData.length > 0;
+
+  return (
+    <MainLayout>
+      <Container>
+        <ProfileSection>
+          <ProfileImage
+            src={profile}
+            alt='Profile'
+          />
+          <UserName>user</UserName>
+          <UserEmail>user@gmail.com</UserEmail>
+        </ProfileSection>
+
+        <ContentSection>
+          <TabLabel>작성한 글</TabLabel>
+        </ContentSection>
+
+        {hasPosts ? (
+          <PostContainer>
+            {sampleData.map((post) => (
+              <PostCard
+                key={post._id}
+                post={post}
+              />
+            ))}
+          </PostContainer>
+        ) : (
+          <MessageContainer>작성한 글이 없습니다.</MessageContainer>
+        )}
+      </Container>
+      <WriteButton />
+    </MainLayout>
+  );
+};
+
+export default UserPage;
+
+const sampleData: Post[] = [
+  {
+    _id: "111",
+    category: "도서",
+    title: "서시",
+    content:
+      "죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다",
+    quote: "인상깊음",
+    author: "테스트123",
+    authorId: "123",
+    date: "2024-10-23",
+    bookmarkCount: "309",
+  },
+  {
+    _id: "112",
+    category: "노래",
+    title: "서시",
+    content:
+      "죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다",
+    quote: "인상깊음",
+    author: "테스트123",
+    authorId: "123",
+    date: "2024-10-23",
+    bookmarkCount: "309",
+  },
+  {
+    _id: "113",
+    category: "대사",
+    title: "서시서시서시서시서시서시서시서시서시서시서시",
+    content:
+      "죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다",
+    quote: "인상깊음",
+    author: "테스트123",
+    authorId: "123",
+    date: "2024-10-23",
+    bookmarkCount: "309",
+  },
+  {
+    _id: "114",
+    category: "인터뷰",
+    title: "서시",
+    content:
+      "죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다",
+    quote: "인상깊음",
+    author: "테스트123",
+    authorId: "123",
+    date: "2024-10-24",
+    bookmarkCount: "119",
+  },
+  {
+    _id: "115",
+    category: "기타",
+    title: "서시",
+    content:
+      "죽는 날까지 하늘을 우러러 한 점 부끄럼이 없기를, 잎새에 이는 바람에도 나는 괴로워했다",
+    quote: "인상깊음",
+    author: "테스트123",
+    authorId: "123",
+    date: "2024-10-24",
+    bookmarkCount: "112",
+  },
+];

--- a/frontend/src/pages/UserPages/components/PostCard.tsx
+++ b/frontend/src/pages/UserPages/components/PostCard.tsx
@@ -1,0 +1,103 @@
+import styled from "styled-components";
+import BookMarkIcon from "@assets/icons/bookMark_before_select.svg?react";
+import { Post } from "@/types/Types";
+import { categoryColors } from "@/styles/Colors";
+
+const PostCardContainer = styled.div`
+  width: 190px;
+  height: 210px;
+  margin: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 20px;
+  overflow: hidden;
+  background-color: ${(props) => props.color};
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.25);
+`;
+
+const PostContentContainer = styled.div`
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(300px - 50px);
+  color: ${(props) => props.color};
+`;
+
+const PostContent = styled.p`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow: hidden;
+  margin: 0;
+  line-height: 24px;
+`;
+
+const PostTitle = styled.p`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  font-size: 10px;
+  font-weight: bold;
+  margin: 0;
+  overflow: hidden;
+`;
+
+const BottomContainer = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 1rem;
+  background-color: #ffffff;
+  font-size: 10px;
+`;
+
+const BookMark = styled.div`
+  width: auto;
+  display: flex;
+  align-items: center;
+  svg {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+`;
+
+const UserText = styled.p`
+  width: 8rem;
+  display: flex;
+  justify-content: end;
+  align-items: center;
+`;
+
+interface PostCardProps {
+  post: Post;
+}
+
+const PostCard = (props: PostCardProps) => {
+  const { post } = props;
+
+  return (
+    <>
+      <PostCardContainer color={categoryColors[post.category].bgColor}>
+        <PostContentContainer color={categoryColors[post.category].fontColor}>
+          <PostContent>{post.content}</PostContent>
+          <PostTitle>{post.title}</PostTitle>
+        </PostContentContainer>
+        <BottomContainer>
+          <BookMark>
+            <BookMarkIcon />
+            {post.bookmarkCount}
+          </BookMark>
+          <UserText>{post.author}</UserText>
+        </BottomContainer>
+      </PostCardContainer>
+    </>
+  );
+};
+
+export default PostCard;

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -3,6 +3,7 @@ import MainPage from "@/pages/MainPage/MainPage";
 import MyPage from "@/pages/MyPages/MyPage";
 import CreatePost from "@/pages/PostCreate/CreatePost";
 import SignUpPage from "@/pages/SignUpPage/SignUpPage";
+import UserPage from "@/pages/UserPages/UserPage";
 import { createBrowserRouter } from "react-router-dom";
 
 const router = createBrowserRouter([
@@ -32,7 +33,7 @@ const router = createBrowserRouter([
   },
   {
     path: "/user-page/:userId",
-    // element:
+    element: <UserPage/>
   },
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "NFE1_2_3_Quote",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 다른 유저 페이지 스타일 적용

## 📝 요구 사항과 구현 내용
- 다른 유저 페이지에서 작성한 글만 보이게 스타일 적용
- 글이 없을 경우 작성한 글이 없다고 표출됨
- 글카드 컴포넌트 분리
- 글쓰기 버튼 추가
- 라우터에 다른 유저 페이지 추가


## 💬 PR 포인트 & 궁금한 점
- 디자인이나 크기 수정해야 할 부분 있으면 말해주세요.
- 외부에 있는 package-lock.json 삭제 하였습니다. 

## 🔗 연관된 이슈
- close #21